### PR TITLE
Added capiocl::Serializer class

### DIFF
--- a/bindings/python_bindings.cpp
+++ b/bindings/python_bindings.cpp
@@ -8,6 +8,14 @@ namespace py = pybind11;
 PYBIND11_MODULE(_py_capio_cl, m) {
     m.doc() =
         "CAPIO-CL: Cross Application Programmable I/O - Coordination Language python bindings.";
+
+    m.attr("MODE_UPDATE")              = py::str(capiocl::MODE_UPDATE);
+    m.attr("MODE_NO_UPDATE")           = py::str(capiocl::MODE_NO_UPDATE);
+    m.attr("COMMITTED_ON_CLOSE")       = py::str(capiocl::COMMITTED_ON_CLOSE);
+    m.attr("COMMITTED_ON_FILE")        = py::str(capiocl::COMMITTED_ON_FILE);
+    m.attr("COMMITTED_N_FILES")        = py::str(capiocl::COMMITTED_N_FILES);
+    m.attr("COMMITTED_ON_TERMINATION") = py::str(capiocl::COMMITTED_ON_TERMINATION);
+
     py::class_<capiocl::Engine>(
         m, "Engine", "The main CAPIO-CL engine for managing data communication and I/O operations.")
         .def(py::init<>())
@@ -54,20 +62,25 @@ PYBIND11_MODULE(_py_capio_cl, m) {
             return "<Engine repr at " + std::to_string(reinterpret_cast<uintptr_t>(&e)) + ">";
         });
 
-    m.attr("MODE_UPDATE")              = py::str(capiocl::MODE_UPDATE);
-    m.attr("MODE_NO_UPDATE")           = py::str(capiocl::MODE_NO_UPDATE);
-    m.attr("COMMITTED_ON_CLOSE")       = py::str(capiocl::COMMITTED_ON_CLOSE);
-    m.attr("COMMITTED_ON_FILE")        = py::str(capiocl::COMMITTED_ON_FILE);
-    m.attr("COMMITTED_N_FILES")        = py::str(capiocl::COMMITTED_N_FILES);
-    m.attr("COMMITTED_ON_TERMINATION") = py::str(capiocl::COMMITTED_ON_TERMINATION);
-
     py::class_<capiocl::Parser>(m, "Parser", "The CAPIO-CL Parser component.")
         .def("parse", &capiocl::Parser::parse)
         .def("__str__",
              [](const capiocl::Parser &e) {
                  return "<Parser repr at " + std::to_string(reinterpret_cast<uintptr_t>(&e)) + ">";
              })
-        .def("__repr__", [](const capiocl::Engine &e) {
+        .def("__repr__", [](const capiocl::Parser &e) {
             return "<Parser repr at " + std::to_string(reinterpret_cast<uintptr_t>(&e)) + ">";
+        });
+
+    py::class_<capiocl::Serializer>(m, "Serializer", "The CAPIO-CL Serializer component.")
+        .def(py::init<>())
+        .def("dump", &capiocl::Serializer::dump)
+        .def("__str__",
+             [](const capiocl::Serializer &e) {
+                 return "<Serializer repr at " + std::to_string(reinterpret_cast<uintptr_t>(&e)) +
+                        ">";
+             })
+        .def("__repr__", [](const capiocl::Serializer &e) {
+            return "<Serializer repr at " + std::to_string(reinterpret_cast<uintptr_t>(&e)) + ">";
         });
 }

--- a/capiocl.hpp
+++ b/capiocl.hpp
@@ -24,6 +24,7 @@
 #endif
 
 namespace capiocl {
+class Serializer;
 
 constexpr char CAPIO_CL_DEFAULT_WF_NAME[] = "CAPIO_CL";
 
@@ -78,7 +79,7 @@ inline void print_message(const std::string &message_type = "",
  * - Storage policy (in-memory or on filesystem)
  */
 class Engine {
-
+    friend class capiocl::Serializer;
     std::string node_name;
 
     /**
@@ -433,8 +434,21 @@ class Parser {
      * the config file
      */
     static std::tuple<std::string, Engine *> parse(const std::filesystem::path &source,
-                                                   const std::filesystem::path &resolve_prexix = "",
+                                                   std::filesystem::path &resolve_prexix,
                                                    bool store_only_in_memory = false);
+};
+
+class Serializer {
+  public:
+    /**
+     * Dump the current configuration loaded into the Engine to a CAPIO-CL configuration file.
+     *
+     * @param engine instance of @class capiocl::Engine to dump
+     * @param workflow_name Name of the current workflow
+     * @param filename path of output file @param filename
+     */
+    static void dump(const Engine &engine, const std::string workflow_name,
+                     const std::filesystem::path &filename);
 };
 } // namespace capiocl
 

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -110,7 +110,7 @@ void capiocl::Engine::print() const {
             } else {
                 line << std::setfill(' ') << std::setw(20) << "|" << std::setfill(' ')
                      << std::setw(13) << "|" << std::setfill(' ') << std::setw(12) << "|"
-                     << std::setfill(' ') << std::setw(10) << "|" << std::setw(10) << "|";
+                     << std::setfill(' ') << std::setw(10) << "|" << std::setw(11) << "|";
             }
 
             print_message(CLI_LEVEL_JSON, line.str());

--- a/src/Serializer.cpp
+++ b/src/Serializer.cpp
@@ -1,0 +1,164 @@
+#include "capiocl.hpp"
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+void capiocl::Serializer::dump(const capiocl::Engine &engine, const std::string workflow_name,
+                               const std::filesystem::path &filename) {
+    START_LOG(gettid(), "call(output='%s')", target.c_str());
+
+    nlohmann::json doc;
+    doc["name"] = workflow_name;
+
+    // Retrieve the files map
+    const auto *files = engine.getLocations(); // adjust if it's a different getter
+
+    // Build helper maps: app → inputs / outputs
+    std::unordered_map<std::string, std::vector<std::string>> app_inputs;
+    std::unordered_map<std::string, std::vector<std::string>> app_outputs;
+
+    // For permanent/exclude/storage
+    std::vector<std::string> permanent;
+    std::vector<std::string> exclude;
+    std::vector<std::string> memory_storage;
+    std::vector<std::string> fs_storage;
+
+    nlohmann::json io_graph = nlohmann::json::array();
+
+    // We'll also need a mapping of each file → its metadata for streaming reconstruction
+    for (const auto &[path, data] : *files) {
+        const auto &[producers, consumers, commit_rule, fire_rule, permanent_flag, excluded_flag,
+                     is_file, n_close, n_dir_files, file_deps, store_in_memory] = data;
+        if (path == "*") {
+            LOG("Skipping * path");
+            print_message(CLI_LEVEL_WARNING, "Skipping * path");
+            continue;
+        }
+
+        // Collect permanent/exclude info
+        if (permanent_flag) {
+            permanent.push_back(path);
+        }
+        if (excluded_flag) {
+            exclude.push_back(path);
+        }
+
+        // Collect storage info
+        if (store_in_memory) {
+            memory_storage.push_back(path);
+        } else {
+            fs_storage.push_back(path);
+        }
+
+        // Collect app relationships
+        for (const auto &p : producers) {
+            app_outputs[p].push_back(path);
+        }
+        for (const auto &c : consumers) {
+            app_inputs[c].push_back(path);
+        }
+    }
+
+    // Construct IO_Graph section
+    for (const auto &[app_name, outputs] : app_outputs) {
+        nlohmann::json app;
+        app["name"] = app_name;
+
+        if (app_inputs.count(app_name)) {
+            app["input_stream"] = app_inputs[app_name];
+        } else {
+            app["input_stream"] = nlohmann::json::array();
+        }
+
+        app["output_stream"] = outputs;
+
+        // ---- streaming ----
+        nlohmann::json streaming = nlohmann::json::array();
+
+        for (const auto &path : outputs) {
+            const auto &data = files->at(path);
+            const auto &[producers, consumers, commit_rule, fire_rule, permanent_flag,
+                         excluded_flag, is_file, n_close, n_dir_files, file_deps, store_in_fs] =
+                data;
+
+            if (path == "*") {
+                LOG("Skipping * path");
+                print_message(CLI_LEVEL_WARNING, "Skipping * path");
+                continue;
+            }
+
+            nlohmann::json sitem;
+            if (is_file) {
+                sitem["name"] = nlohmann::json::array({path});
+            } else {
+                sitem["dirname"] = nlohmann::json::array({path});
+            }
+
+            // Commit rule
+            std::string committed = commit_rule;
+            if (commit_rule == capiocl::COMMITTED_ON_CLOSE && n_close > 0) {
+                committed += ":" + std::to_string(n_close);
+            } else if (commit_rule == capiocl::COMMITTED_N_FILES && n_dir_files > 0) {
+                committed += ":" + std::to_string(n_dir_files);
+            }
+
+            sitem["committed"] = committed;
+
+            // Mode / fire rule
+            sitem["mode"] = fire_rule;
+
+            // File dependencies (for COMMITTED_ON_FILE)
+            if (commit_rule == capiocl::COMMITTED_ON_FILE && !file_deps.empty()) {
+                sitem["file_deps"] = file_deps;
+            }
+
+            // Directory file count
+            if (n_dir_files > 0) {
+                sitem["n_files"] = n_dir_files;
+            }
+
+            streaming.push_back(sitem);
+        }
+
+        if (!streaming.empty()) {
+            app["streaming"] = streaming;
+        }
+
+        io_graph.push_back(app);
+    }
+
+    doc["IO_Graph"] = io_graph;
+
+    // ---- permanent / exclude ----
+    if (!permanent.empty()) {
+        doc["permanent"] = permanent;
+    }
+    if (!exclude.empty()) {
+        doc["exclude"] = exclude;
+    }
+
+    // ---- storage ----
+    nlohmann::json storage;
+    if (!memory_storage.empty()) {
+        storage["memory"] = memory_storage;
+    }
+    if (!fs_storage.empty()) {
+        storage["fs"] = fs_storage;
+    }
+    if (!storage.empty()) {
+        doc["storage"] = storage;
+    }
+
+    // ---- Write JSON ----
+    std::ofstream out(filename);
+    if (!out.is_open()) {
+        std::string msg = "Failed to open output file: " + filename.string();
+        capiocl::print_message(capiocl::CLI_LEVEL_ERROR, msg);
+        ERR_EXIT(msg.c_str());
+    }
+
+    out << std::setw(4) << doc << std::endl;
+
+    capiocl::print_message(capiocl::CLI_LEVEL_INFO,
+                           "Configuration serialized to " + filename.string());
+}


### PR DESCRIPTION
This commit introduces the Serializer class, which allows for dumping an instance of capiocl::Engine to a valid CAPIO-CL configuration file, effectively doing the opposite operation of the capiocl::Parser